### PR TITLE
Changed signer to wallet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var ProviderBridge = require('ethers-provider-bridge');
 var provider = ethers.provider.getDefaultProvider();
 var wallet = new ethers.Wallet(privateKey);
 
-var web3 = new Web3(new ProviderBridge(provider, signer));
+var web3 = new Web3(new ProviderBridge(provider, wallet));
 ```
 
 **Asynchronous**


### PR DESCRIPTION
Just a tiny fix but I believe the `signer` input in the example in the README should be `wallet`. 